### PR TITLE
Scale slides to fit the page.

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -17,8 +17,14 @@
         }, 1000);
     </script>
     <style type="text/css">
+      html, body {
+        height: 100%;
+        width: 100%;
+      }
+    
       body {
         background:url('loading.gif') no-repeat top center;
+        background-size: contain;
       }
 
 


### PR DESCRIPTION
Uses background-size to scale images so that they take up as much room on the page as they can while preserving their aspect ratio.

cc @pranav
